### PR TITLE
Add support for Raspberry Pi 4B 8GB and fix segfault issue with reset function

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -162,7 +162,6 @@ NAN_METHOD(Addon::reset)
     if (ws2811.freq != 0) {
         memset(ws2811.channel[0].leds, 0, sizeof(uint32_t) * ws2811.channel[0].count);
         ws2811_render(&ws2811);
-        ws2811_fini(&ws2811);
     }
 
     ws2811.freq = 0;

--- a/src/rpi_ws281x/rpihw.c
+++ b/src/rpi_ws281x/rpihw.c
@@ -83,6 +83,13 @@ static const rpi_hw_t rpi_hw_info[] = {
         .videocore_base = VIDEOCORE_BASE_RPI2,
         .desc = "Pi 4 Model B - 4GB v1.2"
     },
+    {
+        .hwver = 0xD03114,
+        .type = RPI_HWVER_TYPE_PI4,
+        .periph_base = PERIPH_BASE_RPI4,
+        .videocore_base = VIDEOCORE_BASE_RPI2,
+        .desc = "Pi 4 Model B - 8GB v1.4"
+    },
     //
     // Model B Rev 1.0
     //


### PR DESCRIPTION
The `rpi_ws281x` library can support the Raspberry Pi 4B 8GB v1.4 and thus this revision has been enabled.

Using the `reset` function would constantly yield a segmentation fault and crash the program. In the `addon.cpp` file, the `reset` function definition contains a call to a nonexistent function `ws2811_fini`, which results in the aforementioned segmentation fault problem. Removing this line of code completely fixed the issue and now the `reset` function works perfectly.